### PR TITLE
Rewrite jira.get_children()

### DIFF
--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -118,7 +118,7 @@ def get_blocks(jira_client: jira.client.JIRA, issue: jira.resources.Issue):
 
 
 def get_children(jira_client: jira.client.JIRA, issue: jira.resources.Issue):
-    query = f'"Parent Link" = {issue.key} or "Epic Link" = {issue.key}'
+    query = f'issue in childIssuesOf("{issue.key}") and issue in linksHierarchyIssue("{issue.key}") ORDER BY rank ASC'
     return _search(jira_client, query, verbose=False)
 
 


### PR DESCRIPTION
The function now follows the same pattern than jira.get_parent()

rh-pre-commit.version: 2.0.3
rh-pre-commit.check-secrets: ENABLED