### PR TITLE
Add check_rank automation for Enterprise Contract

### DIFF
--- a/config/ec.yaml
+++ b/config/ec.yaml
@@ -1,0 +1,18 @@
+---
+jira:
+  # url: https://issues.redhat.com
+  project-id: EC
+team_automation:
+  issues:
+    Epic:
+      # collector: get_issues
+      rules: []
+      group_rules:
+        - check_rank
+    Story:
+      # collector: get_issues
+      # Todo: Consider using the filter used by the scrum board,
+      # https://issues.redhat.com/issues/?filter=12422356
+      rules: []
+      group_rules:
+        - check_rank


### PR DESCRIPTION
Introduces a config file for EC. The main motivation is to include the check_rank automation as suggested by KONFLUX-2392.

I'm not confident that we want the other available checks, (for example we do have stories without epics, and epics without parent features, and we do choose our own priority for bugs and stories when grooming), so I'm just adding the `check_rank` option to begin with.

However we don't do much ranking currently, so I think it's safe to try letting the automation do some ranking for us.

(See config/template.yaml for the other automations available.)

Ref: [EC-578](https://issues.redhat.com/browse/EC-578), [KONFLUX-2392](https://issues.redhat.com/browse/KONFLUX-2392)