### PR TITLE
remove check_parent for epics for kfluxdp

### DIFF
--- a/config/kfluxdp.yaml
+++ b/config/kfluxdp.yaml
@@ -5,7 +5,7 @@ jira:
 comments:
   footer: >
     {color:#505f79}See also
-    [kfluxvngd.yaml|https://github.com/konflux-ci/prioritize/blob/main/config/kfluxdp.yaml],
+    [kfluxdp.yaml|https://github.com/konflux-ci/prioritize/blob/main/config/kfluxdp.yaml],
     the [source code|https://github.com/konflux-ci/prioritize], and the
     [runner|https://gitlab.cee.redhat.com/rbean/jira-automation/-/blob/main/.gitlab-ci.yml]
     for this bot.{color}
@@ -14,7 +14,6 @@ team_automation:
     Epic:
       # collector: get_issues
       rules:
-        - check_parent_link
         - check_priority
         - check_due_date
         - check_target_dates


### PR DESCRIPTION
Team discussion has led to us wanting to remove the check_parent check from our project.

Our rationale is that we'd like to be able to use epics to track work that may not necessarily require a parent feature in the KONFLUX project.