### PR TITLE
add task rule and check rank for kfluxdp

### DIFF
--- a/config/kfluxdp.yaml
+++ b/config/kfluxdp.yaml
@@ -25,3 +25,13 @@ team_automation:
         - check_parent_link
         - check_priority
         - check_due_date
+      group_rules:
+        - check_rank
+    Task:
+      # collector: get_issues
+      rules:
+        - check_parent_link
+        - check_priority
+        - check_due_date
+      group_rules:
+        - check_rank


### PR DESCRIPTION
Based on some discussion we realized we could add this automation for the issuetype task, let's see if thats true

and that we didn't have check_rank group rule being used so we added that too