### PR TITLE
remove task and story automation

### DIFF
--- a/config/kfluxdp.yaml
+++ b/config/kfluxdp.yaml
@@ -19,19 +19,3 @@ team_automation:
         - check_target_dates
       group_rules:
         - check_rank
-    Story:
-      # collector: get_issues
-      rules:
-        - check_parent_link
-        - check_priority
-        - check_due_date
-      group_rules:
-        - check_rank
-    Task:
-      # collector: get_issues
-      rules:
-        - check_parent_link
-        - check_priority
-        - check_due_date
-      group_rules:
-        - check_rank

--- a/src/automation.py
+++ b/src/automation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" Apply a set of rules on a project
+"""Apply a set of rules on a project
 
 The project id and the set of rules to apply is managed via a configuration file.
 See the config directory for a template and examples.


### PR DESCRIPTION
We've been experiencing the following issues while using the story and tasks automation

1. Any story or task without a parent gets its priority removed
2. The ordering of our backlog is changed by the bot

Until we have a better system in place to either update this automation or react to these changes we want to remove this automation from taking actions against our stories and tasks for now.

Also fix formatting for black check