### PR TITLE
Provide a more clear message when unsetting target end

### DIFF
--- a/src/rules/program/target_end.py
+++ b/src/rules/program/target_end.py
@@ -7,12 +7,27 @@ from utils.jira import update
 today = strftime("%Y-%m-%d")
 
 
+def listify(epics):
+    ids = [epic.key for epic in epics]
+    if len(ids) == 0:
+        raise ValueError("Cannot listify empty list")
+    elif len(ids) == 1:
+        return ids[0]
+    elif len(ids) == 2:
+        first, last = ids
+        return f"{first} and {last}"
+    else:
+        first, last = ids[:-1], ids[-1]
+        return f"{', '.join(first)} and {last}"
+
+
 def check_target_end_date(
     issue: jira.resources.Issue, context: dict, dry_run: bool
 ) -> None:
     target_end_id = issue.raw["Context"]["Field Ids"]["Target End Date"]
     target_end_date, target_source = None, None
-    estimated_children = 0
+    estimated_children = []
+    unestimated_children = []
 
     children = issue.raw["Context"]["Related Issues"]["Children"]
     children = [
@@ -27,15 +42,16 @@ def check_target_end_date(
     for i in children:
         related_target_end_date = getattr(i.fields, target_end_id)
         if related_target_end_date is None:
+            unestimated_children.append(i)
             continue
-        estimated_children += 1
+        estimated_children.append(i)
         if not target_end_date or target_end_date < related_target_end_date:
             target_end_date = related_target_end_date
             target_source = i
 
     # Only propagate estimates if "most" children have estimates
     if len(children):
-        proportion_estimated = float(estimated_children) / len(children)
+        proportion_estimated = float(len(estimated_children)) / len(children)
     else:
         proportion_estimated = 0
     estimation_threshold = 0.75
@@ -47,7 +63,9 @@ def check_target_end_date(
         target_end_date and (not end_date or end_date != target_end_date)
     ):
         if proportion_estimated < estimation_threshold:
-            message = f"  * Updating Target end date estimate to {target_end_date}. Only {int(proportion_estimated * 100)}% of children have estimates."
+            message = f"  * Updating Target end date estimate to {target_end_date}."
+            message += f"\n  * Only {int(proportion_estimated * 100)}% of children have estimates."
+            message += f"\n  * Set target end dates on child epic(s) {listify(unestimated_children)} to influence the target end date of this Feature."
         else:
             message = f"  * Updating Target end date estimate to {target_end_date}, propagated from child {getattr(target_source, 'key', None)}."
 

--- a/src/tests/test_target_end.py
+++ b/src/tests/test_target_end.py
@@ -1,0 +1,30 @@
+import pytest
+
+from rules.program.target_end import listify
+from tests.conftest import MockIssue
+
+
+def make_epics(keys):
+    return [MockIssue(key, "TEST", None, 0) for key in keys]
+
+
+def test_listify_empty():
+    with pytest.raises(ValueError):
+        listify([])
+
+
+def test_listify_single():
+    epics = make_epics(["E-1"])
+    assert listify(epics) == "E-1"
+
+
+def test_listify_two():
+    epics = make_epics(["E-1", "E-2"])
+    assert listify(epics) == "E-1 and E-2"
+
+
+def test_listify_multiple():
+    epics = make_epics(["E-1", "E-2", "E-3"])
+    assert listify(epics) == "E-1, E-2 and E-3"
+    epics = make_epics(["A", "B", "C", "D"])
+    assert listify(epics) == "A, B, C and D"


### PR DESCRIPTION
People keep getting confused about where to set the target end date.