### PR TITLE
Do not update component list if there is no child

### DIFF
--- a/src/rules/program/components.py
+++ b/src/rules/program/components.py
@@ -6,6 +6,11 @@ from utils.jira import update
 def check_components(issue: jira.resources.Issue, context: dict, dry_run: bool) -> None:
     children = issue.raw["Context"]["Related Issues"]["Children"]
 
+    # Do not update components if there are no children.
+    # In that case the components should be viewed as the expected impact of the issue.
+    if not children:
+        return
+
     child_components = set(sum([i.fields.components for i in children], []))
     child_components = [c.name for c in child_components]
     child_components.sort()


### PR DESCRIPTION
The components are likely set in order to judge the impact of the issue. Once the issue is refined and has children, then the original behavior kicks in.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED