### PR TITLE
fix(target_end): exclude Sub-tasks from target end date calculation

### DIFF
--- a/src/rules/program/target_end.py
+++ b/src/rules/program/target_end.py
@@ -31,6 +31,7 @@ def check_target_end_date(issue: dict, context: dict, dry_run: bool) -> None:
         child
         for child in children
         if child["fields"]["status"]["statusCategory"]["name"] not in ["Done", "Closed"]
+        and child["fields"]["issuetype"]["name"] == "Epic"
     ]
 
     for i in children:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -21,6 +21,7 @@ class MockIssue(dict):
         components=None,
         labels=None,
         status=None,
+        issuetype="Epic",
     ):
         self["Context"] = {}
         self["Context"]["Field Ids"] = {}
@@ -41,6 +42,7 @@ class MockIssue(dict):
         self["fields"]["rice"] = rice
         self["fields"]["components"] = components or [] if components else []
         self["fields"]["labels"] = labels or [] if labels else []
+        self["fields"]["issuetype"] = {"name": issuetype}
 
         # Mock status
         if status is not None:

--- a/src/tests/test_target_end.py
+++ b/src/tests/test_target_end.py
@@ -164,8 +164,12 @@ def test_subtasks_are_excluded_from_target_date_calculation():
     This test verifies the fix for Jira Cloud migration where sub-tasks were incorrectly
     included in children after migration. Only child Epics should influence target end dates.
     """
-    epic_child = make_child_with_target_date("EPIC-1", "In Progress", "2025-08-15", issuetype="Epic")
-    subtask_child = make_child_with_target_date("SUBTASK-1", "In Progress", "2025-12-31", issuetype="Sub-task")
+    epic_child = make_child_with_target_date(
+        "EPIC-1", "In Progress", "2025-08-15", issuetype="Epic"
+    )
+    subtask_child = make_child_with_target_date(
+        "SUBTASK-1", "In Progress", "2025-12-31", issuetype="Sub-task"
+    )
 
     # Parent with both an Epic child and a Sub-task child
     parent = make_parent_with_children(

--- a/src/tests/test_target_end.py
+++ b/src/tests/test_target_end.py
@@ -6,9 +6,9 @@ def make_epics(keys):
     return [MockIssue(key, "TEST", None, 0) for key in keys]
 
 
-def make_child_with_target_date(key, status, target_date):
+def make_child_with_target_date(key, status, target_date, issuetype="Epic"):
     """Helper to create a child issue with a target date."""
-    child = MockIssue(key, "RELEASE", None, 0, status=status)
+    child = MockIssue(key, "RELEASE", None, 0, status=status, issuetype=issuetype)
     child["Context"]["Field Ids"]["Target End Date"] = "customfield_12345"
     child["fields"]["customfield_12345"] = target_date
     return child
@@ -156,3 +156,27 @@ def test_with_active_children_updates_date():
     # Should update to child's date since we have an active child with estimate
     assert len(context["updates"]) == 1
     assert "2025-07-15" in context["updates"][0]
+
+
+def test_subtasks_are_excluded_from_target_date_calculation():
+    """Sub-tasks should be excluded from target end date calculation, only Epics should be included.
+
+    This test verifies the fix for Jira Cloud migration where sub-tasks were incorrectly
+    included in children after migration. Only child Epics should influence target end dates.
+    """
+    epic_child = make_child_with_target_date("EPIC-1", "In Progress", "2025-08-15", issuetype="Epic")
+    subtask_child = make_child_with_target_date("SUBTASK-1", "In Progress", "2025-12-31", issuetype="Sub-task")
+
+    # Parent with both an Epic child and a Sub-task child
+    parent = make_parent_with_children(
+        "FEAT-1", children=[epic_child, subtask_child], target_date="2025-06-30"
+    )
+    context = {"updates": [], "comments": []}
+
+    check_target_end_date(parent, context, dry_run=True)
+
+    # Should only use Epic's date (2025-08-15), not Sub-task's date (2025-12-31)
+    assert len(context["updates"]) == 1
+    assert "2025-08-15" in context["updates"][0]
+    assert "2025-12-31" not in context["updates"][0]
+    assert "EPIC-1" in context["updates"][0]


### PR DESCRIPTION
After Jira Cloud migration, Sub-tasks were incorrectly included in children when calculating target end dates for Features. This caused Features to consider Sub-task dates instead of only Epic dates.

Changes:
- Filter children to only include issuetype == "Epic"
- Update MockIssue test fixture to include issuetype field
- Add test to verify Sub-tasks are excluded from calculation

Verified against KONFLUX-12254 which has 1 Epic and 40 Sub-tasks. Only the Epic should be considered for target end date propagation.

Assisted by: Claude, Cursor