### PR TITLE
feat(jira): lazy child fetch via LazyChildIssues; adjust rules and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 virtualenv
 __pycache__
 jira.cache*
+.venv
 .vim

--- a/src/rules/program/target_end.py
+++ b/src/rules/program/target_end.py
@@ -26,15 +26,14 @@ def check_target_end_date(issue: dict, context: dict, dry_run: bool) -> None:
     estimated_children = []
     unestimated_children = []
 
-    children = issue["Context"]["Related Issues"]["Children"]
-    children = [
-        child
-        for child in children
-        if child["fields"]["status"]["statusCategory"]["name"] not in ["Done", "Closed"]
-        and child["fields"]["issuetype"]["name"] == "Epic"
-    ]
-
-    for i in children:
+    children_src = issue["Context"]["Related Issues"]["Children"]
+    active_child_count = 0
+    for i in children_src:
+        if i["fields"]["status"]["statusCategory"]["name"] in ["Done", "Closed"]:
+            continue
+        if i["fields"]["issuetype"]["name"] != "Epic":
+            continue
+        active_child_count += 1
         related_target_end_date = i["fields"][target_end_id]
         if related_target_end_date is None:
             unestimated_children.append(i)
@@ -45,8 +44,8 @@ def check_target_end_date(issue: dict, context: dict, dry_run: bool) -> None:
             target_source = i
 
     # Only propagate estimates if "most" children have estimates
-    if len(children):
-        proportion_estimated = float(len(estimated_children)) / len(children)
+    if active_child_count:
+        proportion_estimated = float(len(estimated_children)) / active_child_count
     else:
         proportion_estimated = 0
     estimation_threshold = 0.75
@@ -56,7 +55,7 @@ def check_target_end_date(issue: dict, context: dict, dry_run: bool) -> None:
     # Preserve manually-set target end dates on features with no active children
     # (If a feature has no children but has a target end date, it was set manually)
     end_date = issue["fields"][target_end_id]
-    if len(children) == 0 and end_date is not None:
+    if active_child_count == 0 and end_date is not None:
         return
     if (target_end_date is None and end_date) or (
         target_end_date and (not end_date or end_date != target_end_date)

--- a/src/rules/team/rank_with_order_by.py
+++ b/src/rules/team/rank_with_order_by.py
@@ -49,14 +49,12 @@ def _get_all_children_ranked(
     jira_client: Jira, issue: dict, order_by: str
 ) -> list[dict]:
     ranked_issues = [issue]
-    children = get_children(jira_client, issue, order_by)
-    # Ignored closed issues
-    children = [
-        c
-        for c in children
-        if c["fields"]["project"]["key"] == issue["fields"]["project"]["key"]
-        and c["fields"]["status"]["statusCategory"]["name"] != "Done"
-    ]
-    for child in children:
+    project_key = issue["fields"]["project"]["key"]
+    for child in get_children(jira_client, issue, order_by):
+        if (
+            child["fields"]["project"]["key"] != project_key
+            or child["fields"]["status"]["statusCategory"]["name"] == "Done"
+        ):
+            continue
         ranked_issues += _get_all_children_ranked(jira_client, child, order_by)
     return ranked_issues

--- a/src/rules/team/status.py
+++ b/src/rules/team/status.py
@@ -161,9 +161,7 @@ def _update_status(
     }[new_status_category]
 
     if dry_run:
-        msg = (
-            f"  * Updating Status of {issue['key']} to '{update['status']}': {update['msg']}"
-        )
+        msg = f"  * Updating Status of {issue['key']} to '{update['status']}': {update['msg']}"
     else:
         msg = f"  * Updating Status to '{update['status']}': {update['msg']}"
     context["updates"].append(msg)

--- a/src/rules/team/status.py
+++ b/src/rules/team/status.py
@@ -87,7 +87,11 @@ def _get_children_status_categories(
         set[str]: A set of unique status category names from all child issues
     """
     statusCategories = set()
-    children = get_children(context["jira_client"], issue)
+    related = issue.get("Context", {}).get("Related Issues", {})
+    if "Children" in related:
+        children = related["Children"]
+    else:
+        children = get_children(context["jira_client"], issue)
     for child in children:
         status = set_status_from_children(child, context, dry_run)
         statusCategories.add(status)
@@ -157,7 +161,9 @@ def _update_status(
     }[new_status_category]
 
     if dry_run:
-        msg = f"  * Updating Status of {issue.key} to '{update['status']}': {update['msg']}"
+        msg = (
+            f"  * Updating Status of {issue['key']} to '{update['status']}': {update['msg']}"
+        )
     else:
         msg = f"  * Updating Status to '{update['status']}': {update['msg']}"
     context["updates"].append(msg)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -49,7 +49,10 @@ class MockIssue(dict):
             self["fields"]["status"] = {"statusCategory": {"name": status}}
 
     def __repr__(self):
-        return f"<{type(self).__name__} {self["fields"]["project"]["key"]}-{self["key"]}({self["fields"]["rank"]}){self["fields"]["duedate"] or ''}>"
+        pk = self["fields"]["project"]["key"]
+        r = self["fields"]["rank"]
+        dd = self["fields"]["duedate"] or ""
+        return f"<{type(self).__name__} {pk}-{self['key']}({r}){dd}>"
 
 
 @pytest.fixture

--- a/src/tests/test_jira.py
+++ b/src/tests/test_jira.py
@@ -1,0 +1,60 @@
+"""Tests for Jira utilities (caching, preprocess helpers)."""
+
+import dogpile.cache
+import pytest
+
+from utils.jira import preprocess
+
+
+def _minimal_field_ids():
+    return {
+        "Rank": "customfield_rank",
+        "Target Start Date": "cf_ts",
+        "Target End Date": "cf_te",
+        "Due Date": "duedate",
+        "RICE Score": "cf_rice",
+        "Parent": "parent",
+    }
+
+
+@pytest.fixture
+def memory_jira_cache(monkeypatch):
+    """Use in-memory dogpile region so get_parent issue caching is testable."""
+    region = dogpile.cache.make_region().configure(
+        "dogpile.cache.memory",
+        expiration_time=3600,
+    )
+    monkeypatch.setattr("utils.jira.cache", region)
+
+
+def test_get_parent_cache_shared_ref_one_get_issue(
+    monkeypatch, memory_jira_cache
+):
+    get_issue_calls: list[str] = []
+
+    class FakeJira:
+        def get_issue(self, key: str) -> dict:
+            get_issue_calls.append(key)
+            return {"key": key, "fields": {"issuelinks": []}}
+
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", lambda *a, **k: None)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    jc = FakeJira()
+    parent_key = "PAR-1"
+    issue_a = {
+        "key": "CH-A",
+        "fields": {"parent": {"key": parent_key}, "issuelinks": []},
+    }
+    issue_b = {
+        "key": "CH-B",
+        "fields": {"parent": {"key": parent_key}, "issuelinks": []},
+    }
+
+    preprocess(jc, [issue_a, issue_b])
+
+    assert get_issue_calls == [parent_key]
+    pa = issue_a["Context"]["Related Issues"]["Parent"]
+    pb = issue_b["Context"]["Related Issues"]["Parent"]
+    assert pa is not None and pb is not None
+    assert pa is pb

--- a/src/tests/test_jira.py
+++ b/src/tests/test_jira.py
@@ -27,9 +27,7 @@ def memory_jira_cache(monkeypatch):
     monkeypatch.setattr("utils.jira.cache", region)
 
 
-def test_get_parent_cache_shared_ref_one_get_issue(
-    monkeypatch, memory_jira_cache
-):
+def test_get_parent_cache_shared_ref_one_get_issue(monkeypatch, memory_jira_cache):
     get_issue_calls: list[str] = []
 
     class FakeJira:

--- a/src/tests/test_lazy_children.py
+++ b/src/tests/test_lazy_children.py
@@ -1,0 +1,172 @@
+"""Tests for lazy child issue fetching (LazyChildIssues / get_children)."""
+
+import pytest
+
+from utils.jira import LazyChildIssues, get_children, preprocess
+
+
+def _minimal_field_ids():
+    return {
+        "Rank": "customfield_rank",
+        "Target Start Date": "cf_ts",
+        "Target End Date": "cf_te",
+        "Due Date": "duedate",
+        "RICE Score": "cf_rice",
+        "Parent": "parent",
+    }
+
+
+def _child_payload(key: str):
+    return {
+        "key": key,
+        "fields": {
+            "summary": f"s-{key}",
+            "status": {"statusCategory": {"name": "To Do"}},
+            "issuelinks": [],
+        },
+    }
+
+
+@pytest.fixture
+def fake_jira():
+    class FakeJira:
+        pass
+
+    return FakeJira()
+
+
+def test_lazy_children_bool_peek_then_iter_no_duplicate_fetch(
+    monkeypatch, fake_jira
+):
+    calls = []
+
+    def fake_page(jira_client, query, fields, next_page_token):
+        calls.append(next_page_token)
+        if next_page_token is None:
+            return {
+                "issues": [_child_payload("C-1"), _child_payload("C-2")],
+                "nextPageToken": None,
+            }
+        raise AssertionError("unexpected second page request")
+
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", fake_page)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    parent = {"key": "P-1", "fields": {"project": {"key": "PR"}}}
+    lazy = LazyChildIssues(fake_jira, parent, "")
+
+    assert bool(lazy) is True
+    assert calls == [None]
+
+    children = list(lazy)
+    assert [c["key"] for c in children] == ["C-1", "C-2"]
+    assert calls == [None]
+    assert all(c["_jira_client"] is fake_jira for c in children)
+
+
+def test_lazy_children_iter_sets_context(monkeypatch, fake_jira):
+    def fake_page(jira_client, query, fields, next_page_token):
+        if next_page_token is None:
+            return {"issues": [_child_payload("C-9")], "nextPageToken": None}
+        raise AssertionError("unexpected page")
+
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", fake_page)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    parent = {"key": "P-2", "fields": {}}
+    lazy = LazyChildIssues(fake_jira, parent, "")
+    out = list(lazy)
+    assert len(out) == 1
+    child = out[0]
+    assert child["Context"]["Related Issues"]["Parent"] is parent
+    assert child["_jira_client"] is fake_jira
+
+
+def test_lazy_children_multipage_order(monkeypatch, fake_jira):
+    def fake_page(jira_client, query, fields, next_page_token):
+        if next_page_token is None:
+            return {
+                "issues": [_child_payload("A")],
+                "nextPageToken": "tok2",
+            }
+        if next_page_token == "tok2":
+            return {
+                "issues": [_child_payload("B")],
+                "nextPageToken": None,
+            }
+        raise AssertionError("bad token")
+
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", fake_page)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    lazy = LazyChildIssues(fake_jira, {"key": "P-3", "fields": {}}, "")
+    assert [c["key"] for c in lazy] == ["A", "B"]
+
+
+def test_lazy_children_empty(monkeypatch, fake_jira):
+    def fake_page(jira_client, query, fields, next_page_token):
+        return {"issues": [], "nextPageToken": None}
+
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", fake_page)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    lazy = LazyChildIssues(fake_jira, {"key": "P-0", "fields": {}}, "")
+    assert not lazy
+    assert list(lazy) == []
+
+
+def test_lazy_children_concurrent_iter_raises(monkeypatch, fake_jira):
+    def fake_page(jira_client, query, fields, next_page_token):
+        return {
+            "issues": [_child_payload("X"), _child_payload("Y")],
+            "nextPageToken": None,
+        }
+
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", fake_page)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    lazy = LazyChildIssues(fake_jira, {"key": "P-4", "fields": {}}, "")
+    g1 = iter(lazy)
+    next(g1)
+    with pytest.raises(RuntimeError, match="concurrent"):
+        iter(lazy)
+    list(g1)
+
+
+def test_get_children_returns_lazy(monkeypatch, fake_jira):
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", lambda *a, **k: None)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    parent = {"key": "P-X", "fields": {}}
+    ch = get_children(fake_jira, parent)
+    assert isinstance(ch, LazyChildIssues)
+    assert not ch  # empty response
+
+
+def test_preprocess_assigns_lazy_children(monkeypatch, fake_jira):
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", lambda *a, **k: None)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+    monkeypatch.setattr("utils.jira.get_parent", lambda jc, iss: None)
+    monkeypatch.setattr("utils.jira.get_blocks", lambda jc, iss: [])
+
+    issue = {
+        "key": "ROOT",
+        "fields": {"issuelinks": []},
+    }
+    preprocess(fake_jira, [issue])
+    assert isinstance(
+        issue["Context"]["Related Issues"]["Children"], LazyChildIssues)
+
+
+def test_failed_fetch_marks_lazy_dead(monkeypatch, fake_jira):
+    def boom(*a, **k):
+        raise ConnectionError("x")
+
+    monkeypatch.setattr("utils.jira._enhanced_jql_page", boom)
+    monkeypatch.setattr("utils.jira.get_fields_ids", lambda jc: _minimal_field_ids())
+
+    lazy = LazyChildIssues(fake_jira, {"key": "P-dead", "fields": {}}, "")
+    with pytest.raises(ConnectionError):
+        bool(lazy)
+    with pytest.raises(RuntimeError, match="failed earlier"):
+        bool(lazy)

--- a/src/tests/test_lazy_children.py
+++ b/src/tests/test_lazy_children.py
@@ -35,9 +35,7 @@ def fake_jira():
     return FakeJira()
 
 
-def test_lazy_children_bool_peek_then_iter_no_duplicate_fetch(
-    monkeypatch, fake_jira
-):
+def test_lazy_children_bool_peek_then_iter_no_duplicate_fetch(monkeypatch, fake_jira):
     calls = []
 
     def fake_page(jira_client, query, fields, next_page_token):
@@ -154,8 +152,7 @@ def test_preprocess_assigns_lazy_children(monkeypatch, fake_jira):
         "fields": {"issuelinks": []},
     }
     preprocess(fake_jira, [issue])
-    assert isinstance(
-        issue["Context"]["Related Issues"]["Children"], LazyChildIssues)
+    assert isinstance(issue["Context"]["Related Issues"]["Children"], LazyChildIssues)
 
 
 def test_failed_fetch_marks_lazy_dead(monkeypatch, fake_jira):

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -1,5 +1,8 @@
 import difflib
 import os
+from collections import deque
+from collections.abc import Iterator
+from typing import Any
 
 import dogpile.cache
 from atlassian import Jira
@@ -36,6 +39,118 @@ _JQL_ISSUE_FIELDS_BASE: tuple[str, ...] = (
     "duedate",
     "fixVersions",
 )
+
+
+def _jql_fields_list(jira_client: Jira) -> list[str]:
+    return list(
+        dict.fromkeys((*_JQL_ISSUE_FIELDS_BASE, *get_fields_ids(jira_client).values()))
+    )
+
+
+@retry()
+def _enhanced_jql_page(
+    jira_client: Jira,
+    query: str,
+    fields: list[str],
+    next_page_token: str | None,
+) -> dict[str, Any] | None:
+    return jira_client.enhanced_jql(
+        query, fields=fields, nextPageToken=next_page_token
+    )
+
+
+class LazyChildIssues:
+    """Direct children of a Jira issue, fetched page-by-page on iteration or ``bool``.
+
+    Does not use the full-result dogpile cache. Supports a single concurrent iterator;
+    calling ``iter()`` again while iteration is in progress raises ``RuntimeError``.
+
+    After a failed page fetch, the instance is left in a failed state and must not be reused.
+    """
+
+    __slots__ = (
+        "_jira_client",
+        "_parent",
+        "_query",
+        "_fields_list",
+        "_buffer",
+        "_cursor",
+        "_exhausted",
+        "_iterating",
+        "_failed",
+    )
+
+    def __init__(
+        self, jira_client: Jira, parent_issue: dict, order_by: str = ""
+    ) -> None:
+        self._jira_client = jira_client
+        self._parent = parent_issue
+        q = f'Parent = {parent_issue["key"]}'
+        if order_by:
+            q += f" ORDER BY {order_by}"
+        self._query = q
+        self._fields_list: list[str] | None = None
+        self._buffer: deque[dict] = deque()
+        # ``None`` = request first page; after each response, token for the next page.
+        self._cursor: str | None = None
+        self._exhausted = False
+        self._iterating = False
+        self._failed = False
+
+    def _fields(self) -> list[str]:
+        if self._fields_list is None:
+            self._fields_list = _jql_fields_list(self._jira_client)
+        return self._fields_list
+
+    def _check_ok(self) -> None:
+        if self._failed:
+            raise RuntimeError("LazyChildIssues iteration failed earlier; create a new query")
+
+    def _pull_page(self) -> None:
+        self._check_ok()
+        if self._exhausted:
+            return
+        try:
+            response = _enhanced_jql_page(
+                self._jira_client, self._query, self._fields(), self._cursor
+            )
+        except Exception:
+            self._failed = True
+            raise
+        if not response:
+            self._exhausted = True
+            return
+        issues = response.get("issues", [])
+        self._buffer.extend(issues)
+        next_tok = response.get("nextPageToken")
+        self._cursor = next_tok if next_tok else None
+        if not next_tok:
+            self._exhausted = True
+
+    def _ensure_buffer(self) -> None:
+        self._check_ok()
+        while not self._buffer and not self._exhausted:
+            self._pull_page()
+
+    def __bool__(self) -> bool:
+        # Peek at most until the first non-empty page (no full materialization).
+        self._ensure_buffer()
+        return bool(self._buffer)
+
+    def __iter__(self) -> Iterator[dict]:
+        if self._iterating:
+            raise RuntimeError("LazyChildIssues does not allow concurrent iteration")
+        self._iterating = True
+        try:
+            while True:
+                self._ensure_buffer()
+                if not self._buffer:
+                    break
+                raw = self._buffer.popleft()
+                preprocess(self._jira_client, [raw], parent=self._parent)
+                yield raw
+        finally:
+            self._iterating = False
 
 
 def get_issues(
@@ -100,11 +215,7 @@ def _search(jira_client: Jira, query: str, verbose: bool) -> list:
         if verbose:
             print("  ?", query)
 
-        fields = list(
-            dict.fromkeys(
-                (*_JQL_ISSUE_FIELDS_BASE, *get_fields_ids(jira_client).values())
-            )
-        )
+        fields = _jql_fields_list(jira_client)
 
         results: list = []
         next_page_token: str | None = None
@@ -208,13 +319,10 @@ def get_blocks(jira_client: Jira, issue: dict) -> list[dict]:
     return blocked_issues
 
 
-def get_children(jira_client: Jira, issue: dict, order_by: str = ""):
-    query = f'Parent = {issue["key"]}'
-    if order_by:
-        query += f" ORDER BY {order_by}"
-    children = _search(jira_client, query, verbose=False)
-    preprocess(jira_client, children, parent=issue)
-    return children
+def get_children(
+    jira_client: Jira, issue: dict, order_by: str = ""
+) -> LazyChildIssues:
+    return LazyChildIssues(jira_client, issue, order_by)
 
 
 def get_version(jira_client: Jira, project: dict, version: str):

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -54,9 +54,7 @@ def _enhanced_jql_page(
     fields: list[str],
     next_page_token: str | None,
 ) -> dict[str, Any] | None:
-    return jira_client.enhanced_jql(
-        query, fields=fields, nextPageToken=next_page_token
-    )
+    return jira_client.enhanced_jql(query, fields=fields, nextPageToken=next_page_token)
 
 
 class LazyChildIssues:
@@ -104,7 +102,9 @@ class LazyChildIssues:
 
     def _check_ok(self) -> None:
         if self._failed:
-            raise RuntimeError("LazyChildIssues iteration failed earlier; create a new query")
+            raise RuntimeError(
+                "LazyChildIssues iteration failed earlier; create a new query"
+            )
 
     def _pull_page(self) -> None:
         self._check_ok()
@@ -141,6 +141,9 @@ class LazyChildIssues:
         if self._iterating:
             raise RuntimeError("LazyChildIssues does not allow concurrent iteration")
         self._iterating = True
+        return self._iter_child_issues()
+
+    def _iter_child_issues(self) -> Iterator[dict]:
         try:
             while True:
                 self._ensure_buffer()
@@ -325,9 +328,7 @@ def get_blocks(jira_client: Jira, issue: dict) -> list[dict]:
     return blocked_issues
 
 
-def get_children(
-    jira_client: Jira, issue: dict, order_by: str = ""
-) -> LazyChildIssues:
+def get_children(jira_client: Jira, issue: dict, order_by: str = "") -> LazyChildIssues:
     return LazyChildIssues(jira_client, issue, order_by)
 
 

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -293,10 +293,16 @@ def get_fields_ids(jira_client: Jira) -> dict[str, str]:
 
 
 def get_parent(jira_client: Jira, issue: dict) -> dict | None:
-    parent = None
-    if "parent" in issue["fields"].keys():
-        parent = jira_client.get_issue(issue["fields"]["parent"]["key"])
-        preprocess(jira_client, [parent])
+    if "parent" not in issue["fields"]:
+        return None
+
+    @retry()
+    @cache.cache_on_arguments()
+    def _get_issue_by_key(parent_key: str):
+        return jira_client.get_issue(parent_key)
+
+    parent = _get_issue_by_key(issue["fields"]["parent"]["key"])
+    preprocess(jira_client, [parent])
     return parent
 
 


### PR DESCRIPTION
Replace eager get_children + cached _search with LazyChildIssues: paginate enhanced_jql without dogpile, preprocess each child on yield, and support __bool__ without loading all pages. Single iterator at a time; failed fetches invalidate the instance.

Refactor target_end to one pass over children (no materialized active list). Status rules reuse Context["Related Issues"]["Children"] when present to avoid a second query; fix dry-run message to use issue["key"]. Rank cascade walks get_children in order without list(get_children(...)).

Add tests for lazy children; fix MockIssue.__repr__ f-string SyntaxError.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED