### PR TITLE
feat: add blocker propagation to parent issues

### DIFF
--- a/config/ec.yaml
+++ b/config/ec.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: EC
 comments:
   footer: >
@@ -13,7 +13,8 @@ team_automation:
   issues:
     Epic:
       # collector: get_issues
-      rules: []
+      rules:
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
     Story:

--- a/config/kfluxdp.yaml
+++ b/config/kfluxdp.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: KFLUXDP
 comments:
   footer: >
@@ -17,5 +17,9 @@ team_automation:
         - check_priority
         - check_due_date
         - check_target_dates
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
+    Feature:
+      rules:
+        - sync_blocker_links_from_descendants

--- a/config/kfluxinfra.yaml
+++ b/config/kfluxinfra.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: KFLUXINFRA
 comments:
   footer: >
@@ -26,6 +26,7 @@ team_automation:
             ignore: >
               .key in ["KFLUXINFRA-34"]
         - check_target_dates
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
     Story:

--- a/config/kfluxsprt.yaml
+++ b/config/kfluxsprt.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: KFLUXSPRT
 comments:
   footer: >
@@ -16,6 +16,7 @@ team_automation:
       rules:
         - check_due_date
         - check_target_dates
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
     Story:

--- a/config/kfluxvngd.yaml
+++ b/config/kfluxvngd.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: KFLUXVNGD
 comments:
   footer: >
@@ -18,6 +18,7 @@ team_automation:
         - check_priority
         - check_due_date
         - check_target_dates
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
     Story:

--- a/config/konflux.yaml
+++ b/config/konflux.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: KONFLUX
   subquery: filter!=106098
 comments:
@@ -27,6 +27,7 @@ team_automation:
       # collector: get_issues
       rules:
         - check_due_date_by_fixversion
+        - sync_blocker_links_from_descendants
       group_rules:
         - rule: check_timesensitive_rank
           kwargs:
@@ -41,8 +42,8 @@ team_automation:
           kwargs:
             ignore: ["user-origin"]
     Epic:
-      collector: get_child_issues
       rules:
+        - sync_blocker_links_from_descendants
         - rule: check_due_date
           kwargs:
             # This is a CEL expression

--- a/config/release.yaml
+++ b/config/release.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: RELEASE
 comments:
   footer: >
@@ -23,6 +23,7 @@ team_automation:
             ignore: >
               .key in ["RELEASE-852"]
         - check_target_dates
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
     Story:

--- a/config/rhtap.yaml
+++ b/config/rhtap.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: RHTAP
 comments:
   footer: >
@@ -15,6 +15,7 @@ team_automation:
       # collector: get_issues
       rules:
         - set_status_from_children
+        - sync_blocker_links_from_descendants
       group_rules:
         - rule: check_rank_with_order_by
           kwargs:
@@ -24,6 +25,7 @@ team_automation:
       # collector: get_issues
       rules:
         - check_parent_link
+        - sync_blocker_links_from_descendants
         # - set_fix_version
     Story:
       # collector: get_issues

--- a/config/rhtapinst.yaml
+++ b/config/rhtapinst.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: RHTAPINST
 comments:
   footer: >
@@ -19,6 +19,7 @@ team_automation:
         - check_due_date
         - check_target_dates
         - set_fix_version
+        - sync_blocker_links_from_descendants
       group_rules:
         - rule: check_rank
           kwargs:

--- a/config/stonebld.yaml
+++ b/config/stonebld.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: STONEBLD
 comments:
   footer: >
@@ -27,6 +27,7 @@ team_automation:
               .key in ["STONEBLD-1941"]
         - check_target_dates
         - set_fix_version
+        - sync_blocker_links_from_descendants
       group_rules:
         - rule: check_rank
           kwargs:

--- a/config/stoneintg.yaml
+++ b/config/stoneintg.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id: STONEINTG
 comments:
   footer: >
@@ -22,6 +22,7 @@ team_automation:
             ignore: >
               .key in ["STONEINTG-767"]
         - check_target_dates
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
     Story:

--- a/config/template.yaml
+++ b/config/template.yaml
@@ -1,6 +1,6 @@
 ---
 jira:
-  # url: https://issues.redhat.com
+  url: https://redhat.atlassian.net
   project-id:  # PROJECT_KEY
 comments:
   footer: >
@@ -19,6 +19,7 @@ team_automation:
         - check_due_date
         - check_target_dates
         - set_fix_version
+        - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
     Story:

--- a/src/automation.py
+++ b/src/automation.py
@@ -122,6 +122,9 @@ def process_type(
         set_non_compliant_flag(issue, context, dry_run)
         add_comment(issue, context, dry_run, footer)
 
+    if not issues:
+        return
+
     context = {
         "comments": [],
         "jira_client": jira_client,

--- a/src/rules/team/__init__.py
+++ b/src/rules/team/__init__.py
@@ -1,3 +1,4 @@
+from .blocker_propagation import sync_blocker_links_from_descendants
 from .due_date import check_due_date
 from .due_date_by_fixversion import check_due_date_by_fixversion
 from .fixversion_rank import check_fixversion_rank
@@ -14,6 +15,7 @@ from .target_dates import check_target_dates
 from .timesensitive_rank import check_timesensitive_rank
 
 __all__ = [
+    sync_blocker_links_from_descendants,
     check_due_date,
     check_due_date_by_fixversion,
     set_fix_version,

--- a/src/rules/team/blocker_propagation.py
+++ b/src/rules/team/blocker_propagation.py
@@ -1,0 +1,180 @@
+"""
+When a child issue gains or loses a "is blocked by" link, the next bot run adds or removes the
+corresponding link on the parent issue so parents reflect rollup state.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Collection
+
+from atlassian import Jira
+
+from utils.jira import get_descendant_issues
+
+
+def _is_blocked_by_link_type(link_type: dict | None) -> bool:
+    """
+    Detect issue links where the *inward* issue "is blocked by" the *outward* issue.
+    """
+    if not link_type:
+        return False
+    name = (link_type.get("name") or "").lower()
+    if name in ("blocks", "blockers"):
+        return True
+    inward = (link_type.get("inward") or "").lower()
+    if "blocked" in inward and "by" in inward:
+        return True
+    return False
+
+
+def _blocking_issue_keys(issue: dict) -> list[str]:
+    """
+    Keys of issues that *block* ``issue`` (i.e. ``issue`` is blocked by them).
+    """
+    keys: list[str] = []
+    my_key = issue["key"]
+    for il in issue["fields"].get("issuelinks", []) or []:
+        if not _is_blocked_by_link_type(il.get("type")):
+            continue
+        inward_key = (il.get("inwardIssue") or {}).get("key")
+        if inward_key and inward_key != my_key:
+            keys.append(inward_key)
+    return keys
+
+
+def _inward_blocks_entries(issue: dict) -> list[tuple[str, str]]:
+    """(blocker_key, link_id) for blocked-by links on this issue."""
+    out: list[tuple[str, str]] = []
+    my_key = issue["key"]
+    for il in issue["fields"].get("issuelinks", []) or []:
+        if not _is_blocked_by_link_type(il.get("type")):
+            continue
+        inward_key = (il.get("inwardIssue") or {}).get("key")
+        if inward_key and inward_key != my_key:
+            lid = il.get("id")
+            if lid is not None:
+                out.append((inward_key, str(lid)))
+    return out
+
+
+_BATCH_SIZE = 50
+
+
+def _batch_merge_issuelinks(jira_client: Jira, issues: list[dict]) -> None:
+    """Fetch issuelinks for many issues in batched JQL queries."""
+    if not issues:
+        return
+    by_key = {}
+    for iss in issues:
+        by_key[iss["key"]] = iss
+
+    keys = list(by_key.keys())
+    for offset in range(0, len(keys), _BATCH_SIZE):
+        batch = keys[offset : offset + _BATCH_SIZE]  # noqa: E203
+        jql = f'key in ({",".join(batch)})'
+        next_page_token: str | None = None
+        while True:
+            response = jira_client.enhanced_jql(
+                jql, fields=["issuelinks"], nextPageToken=next_page_token
+            )
+            if not response:
+                break
+            for result in response.get("issues", []):
+                key = result.get("key")
+                if key and key in by_key:
+                    fields = result.get("fields") or {}
+                    by_key[key].setdefault("fields", {})
+                    if "issuelinks" in fields:
+                        by_key[key]["fields"]["issuelinks"] = fields["issuelinks"] or []
+            next_page_token = response.get("nextPageToken")
+            if not next_page_token:
+                break
+
+
+def sync_blocker_links_from_descendants(
+    issue: dict,
+    context: dict,
+    dry_run: bool,
+    container_issue_types: Collection[str] | None = None,
+    link_type_name: str = "Blocks",
+    **_: Any,
+) -> None:
+    """
+    For an Epic or Feature, set "is blocked by" to exactly the union of blockers on
+    all descendant issues (any issue type under the Parent hierarchy), adding and
+    removing Issue Links as needed.
+    """
+    if container_issue_types is None:
+        container_issue_types = ("Epic", "Feature")
+
+    itype = (issue["fields"].get("issuetype") or {}).get("name")
+    if itype not in container_issue_types:
+        return
+
+    jira_client: Jira = context["jira_client"]
+    descendants = get_descendant_issues(jira_client, issue["key"], unresolved_only=True)
+    if not descendants:
+        if os.environ.get("PRIORITIZE_BLOCKER_DIAG"):
+            context["updates"].append(
+                f"  * Blocker sync: 0 descendants for {issue['key']} "
+                "(JQL: Parent/parent/Epic Link). Child must use one of these to the Epic."
+            )
+        return
+
+    _batch_merge_issuelinks(jira_client, [issue, *descendants])
+
+    desired: set[str] = set()
+    for d in descendants:
+        desired |= set(_blocking_issue_keys(d))
+
+    my_key = issue["key"]
+    entries = _inward_blocks_entries(issue)
+    current_by_blocker = {b: lid for b, lid in entries}
+
+    to_add = sorted(desired - current_by_blocker.keys())
+    to_remove = sorted(current_by_blocker.keys() - desired)
+
+    if (
+        os.environ.get("PRIORITIZE_BLOCKER_DIAG")
+        and dry_run
+        and not to_add
+        and not to_remove
+    ):
+        context["updates"].append(
+            f"  * Blocker sync: {len(descendants)} descendant(s); "
+            "union of inward Blocks on descendants matches Epic (nothing to change)."
+        )
+    if os.environ.get("PRIORITIZE_BLOCKER_DIAG") == "2":
+        desc_keys = sorted(d["key"] for d in descendants)
+        context["updates"].append(
+            f"  * Blocker sync DEBUG: descendant_keys={desc_keys} "
+            f"desired_blockers={sorted(desired)} "
+            f"epic_inward_blockers={sorted(current_by_blocker.keys())} "
+            f"to_add={to_add} to_remove={to_remove}"
+        )
+
+    for blocker in to_add:
+        if blocker == my_key:
+            continue
+        # Jira Cloud create: inwardIssue=blocker, outwardIssue=blocked party
+        payload = {
+            "type": {"name": link_type_name},
+            "inwardIssue": {"key": blocker},
+            "outwardIssue": {"key": my_key},
+        }
+        msg = f"  * Add link: {my_key} is blocked by {blocker}"
+        if dry_run:
+            context["updates"].append(f"{msg} [dry-run, not created]")
+        else:
+            jira_client.create_issue_link(payload)
+            context["updates"].append(f"{msg} [created]")
+
+    for blocker in to_remove:
+        link_id = current_by_blocker[blocker]
+        msg = f"  * Remove link: {my_key} is blocked by {blocker}"
+        if dry_run:
+            context["updates"].append(f"{msg} [dry-run, not removed]")
+        else:
+            jira_client.remove_issue_link(link_id)
+            context["updates"].append(f"{msg} [removed]")

--- a/src/tests/test_blocker_propagation.py
+++ b/src/tests/test_blocker_propagation.py
@@ -1,0 +1,627 @@
+"""
+Jira Cloud GET response semantics for Blocks links viewed from issue X:
+    inwardIssue: Y  → X "is blocked by" Y  (Y is the blocker)
+    outwardIssue: Y → X "blocks" Y          (Y is NOT a blocker of X)
+"""
+
+import unittest.mock as mock
+
+import rules.team.blocker_propagation as bp
+from utils.jira import get_descendant_issues
+
+
+def _issue(
+    key: str,
+    issuetype: str,
+    *,
+    issuelinks: list | None = None,
+    parent_key: str | None = None,
+    resolution: str | None = None,
+) -> dict:
+    fields: dict = {"issuetype": {"name": issuetype}, "issuelinks": issuelinks or []}
+    if parent_key is not None:
+        fields["parent"] = {"key": parent_key}
+    fields["resolution"] = {"name": resolution} if resolution else None
+    return {"key": key, "fields": fields}
+
+
+def _blocked_by_link(my_key: str, blocker: str, link_id: str = "10001") -> dict:
+    """Simulate Jira Cloud GET: ``my_key`` is blocked by ``blocker``."""
+    return {
+        "id": link_id,
+        "type": {"name": "Blocks"},
+        "inwardIssue": {"key": blocker},
+    }
+
+
+def test_blocking_issue_keys_detects_blocker():
+    story = _issue(
+        "KFLUXDP-10",
+        "Story",
+        issuelinks=[_blocked_by_link("KFLUXDP-10", "KFLUXDP-99")],
+    )
+    assert bp._blocking_issue_keys(story) == ["KFLUXDP-99"]
+
+
+def test_blocking_issue_keys_outward_means_current_blocks_not_blocked():
+    """outwardIssue: Y means current blocks Y — not a blocker of current."""
+    link = {
+        "id": "1",
+        "type": {"name": "Blocks"},
+        "outwardIssue": {"key": "KFLUXDP-99"},
+    }
+    story = _issue("KFLUXDP-10", "Story", issuelinks=[link])
+    assert bp._blocking_issue_keys(story) == []
+
+
+def test_blocking_issue_keys_ignores_inward_self_reference():
+    """If inwardIssue is somehow the issue itself, skip it."""
+    link = {
+        "id": "1",
+        "type": {"name": "Blocks"},
+        "inwardIssue": {"key": "KFLUXDP-10"},
+    }
+    story = _issue("KFLUXDP-10", "Story", issuelinks=[link])
+    assert bp._blocking_issue_keys(story) == []
+
+
+def test_blocking_issue_keys_detects_by_inward_label_not_name():
+    """Custom link types may omit name 'Blocks' but keep inward 'is blocked by'."""
+    link = {
+        "id": "1",
+        "type": {
+            "name": "CustomDependency",
+            "inward": "is blocked by",
+            "outward": "blocks",
+        },
+        "inwardIssue": {"key": "KFLUXDP-99"},
+    }
+    story = _issue("KFLUXDP-10", "Story", issuelinks=[link])
+    assert bp._blocking_issue_keys(story) == ["KFLUXDP-99"]
+
+
+def test_inward_blocks_entries_with_ids():
+    epic = _issue(
+        "KFLUXDP-30",
+        "Epic",
+        issuelinks=[
+            _blocked_by_link("KFLUXDP-30", "KFLUXDP-99", "1"),
+            _blocked_by_link("KFLUXDP-30", "KFLUXDP-98", "2"),
+        ],
+    )
+    entries = bp._inward_blocks_entries(epic)
+    assert set(entries) == {("KFLUXDP-99", "1"), ("KFLUXDP-98", "2")}
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_adds_missing_blockers(mock_desc, _mock_batch):
+    epic = _issue("KFLUXDP-30", "Epic", issuelinks=[])
+    s1 = _issue(
+        "KFLUXDP-11", "Story", issuelinks=[_blocked_by_link("KFLUXDP-11", "B1")]
+    )
+    s2 = _issue(
+        "KFLUXDP-12", "Story", issuelinks=[_blocked_by_link("KFLUXDP-12", "B2")]
+    )
+    mock_desc.return_value = [s1, s2]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=False)
+
+    calls = jira_client.create_issue_link.call_args_list
+    assert len(calls) == 2
+    payloads = [c[0][0] for c in calls]
+    # Jira Cloud create: inwardIssue=blocker, outwardIssue=blocked party (epic)
+    assert {
+        frozenset(
+            (("inward", p["inwardIssue"]["key"]), ("outward", p["outwardIssue"]["key"]))
+        )
+        for p in payloads
+    } == {
+        frozenset((("inward", "B1"), ("outward", "KFLUXDP-30"))),
+        frozenset((("inward", "B2"), ("outward", "KFLUXDP-30"))),
+    }
+    jira_client.remove_issue_link.assert_not_called()
+    assert all("[created]" in u for u in context["updates"])
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_removes_stale_blockers(mock_desc, _mock_batch):
+    epic = _issue(
+        "KFLUXDP-30",
+        "Epic",
+        issuelinks=[
+            _blocked_by_link("KFLUXDP-30", "OLD", "50"),
+            _blocked_by_link("KFLUXDP-30", "KEEP", "51"),
+        ],
+    )
+    s1 = _issue(
+        "KFLUXDP-11", "Story", issuelinks=[_blocked_by_link("KFLUXDP-11", "KEEP")]
+    )
+    mock_desc.return_value = [s1]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=False)
+
+    jira_client.remove_issue_link.assert_called_once_with("50")
+    jira_client.create_issue_link.assert_not_called()
+    assert any("[removed]" in u for u in context["updates"])
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_skips_non_container(mock_desc, _mock_batch):
+    story = _issue("KFLUXDP-10", "Story", issuelinks=[])
+    mock_desc.return_value = []
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(story, context, dry_run=False)
+
+    mock_desc.assert_not_called()
+    jira_client.create_issue_link.assert_not_called()
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_skips_when_no_descendants(mock_desc, _mock_batch):
+    epic = _issue(
+        "KFLUXDP-30", "Epic", issuelinks=[_blocked_by_link("KFLUXDP-30", "X")]
+    )
+    mock_desc.return_value = []
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=False)
+
+    jira_client.create_issue_link.assert_not_called()
+    jira_client.remove_issue_link.assert_not_called()
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_dry_run(mock_desc, _mock_batch):
+    epic = _issue("KFLUXDP-30", "Epic", issuelinks=[])
+    mock_desc.return_value = [
+        _issue("KFLUXDP-11", "Story", issuelinks=[_blocked_by_link("KFLUXDP-11", "B1")])
+    ]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=True)
+
+    jira_client.create_issue_link.assert_not_called()
+    assert context["updates"] and "dry-run" in context["updates"][0]
+
+
+def test_blocking_issue_keys_handles_null_issuelinks():
+    """issuelinks field can be None or absent; should return empty list."""
+    issue_none = {"key": "X-1", "fields": {"issuelinks": None}}
+    assert bp._blocking_issue_keys(issue_none) == []
+
+    issue_missing = {"key": "X-2", "fields": {}}
+    assert bp._blocking_issue_keys(issue_missing) == []
+
+
+def test_is_blocked_by_link_type_edge_cases():
+    assert bp._is_blocked_by_link_type(None) is False
+    assert bp._is_blocked_by_link_type({}) is False
+    assert bp._is_blocked_by_link_type({"name": "Blockers"}) is True
+    assert bp._is_blocked_by_link_type({"name": "Relates"}) is False
+
+
+def test_blocking_issue_keys_skips_non_blocks_link_types():
+    """Non-Blocks links (e.g. Cloners, Relates) should be skipped via continue."""
+    relates_link = {
+        "id": "99",
+        "type": {"name": "Relates"},
+        "inwardIssue": {"key": "NOISE-1"},
+    }
+    blocks_link = _blocked_by_link("X-1", "REAL-1")
+    issue = _issue("X-1", "Story", issuelinks=[relates_link, blocks_link])
+    assert bp._blocking_issue_keys(issue) == ["REAL-1"]
+
+
+def test_inward_blocks_entries_skips_non_blocks_and_missing_id():
+    """Non-Blocks links hit continue; links without id are skipped."""
+    relates_link = {
+        "id": "99",
+        "type": {"name": "Relates"},
+        "inwardIssue": {"key": "NOISE-1"},
+    }
+    no_id_link = {
+        "type": {"name": "Blocks"},
+        "inwardIssue": {"key": "NO-ID"},
+    }
+    good_link = _blocked_by_link("X-1", "OK-1", "42")
+    issue = _issue("X-1", "Epic", issuelinks=[relates_link, no_id_link, good_link])
+    assert bp._inward_blocks_entries(issue) == [("OK-1", "42")]
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_works_on_feature(mock_desc, _mock_batch):
+    """Feature is a valid container type, not just Epic."""
+    feature = _issue("KONFLUX-100", "Feature", issuelinks=[])
+    child = _issue(
+        "KONFLUX-200", "Epic", issuelinks=[_blocked_by_link("KONFLUX-200", "EXT-1")]
+    )
+    mock_desc.return_value = [child]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(feature, context, dry_run=False)
+
+    calls = jira_client.create_issue_link.call_args_list
+    assert len(calls) == 1
+    payload = calls[0][0][0]
+    assert payload["inwardIssue"]["key"] == "EXT-1"
+    assert payload["outwardIssue"]["key"] == "KONFLUX-100"
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_deduplicates_same_blocker_across_children(mock_desc, _mock_batch):
+    """Two children blocked by the same issue should produce one link on the Epic."""
+    epic = _issue("KFLUXDP-30", "Epic", issuelinks=[])
+    s1 = _issue(
+        "KFLUXDP-11", "Story", issuelinks=[_blocked_by_link("KFLUXDP-11", "B1")]
+    )
+    s2 = _issue(
+        "KFLUXDP-12", "Story", issuelinks=[_blocked_by_link("KFLUXDP-12", "B1")]
+    )
+    mock_desc.return_value = [s1, s2]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=False)
+
+    assert jira_client.create_issue_link.call_count == 1
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_skips_self_blocker(mock_desc, _mock_batch):
+    """If a descendant is 'blocked by' the Epic itself, don't create a self-link."""
+    epic = _issue("KFLUXDP-30", "Epic", issuelinks=[])
+    child = _issue(
+        "KFLUXDP-11",
+        "Story",
+        issuelinks=[_blocked_by_link("KFLUXDP-11", "KFLUXDP-30")],
+    )
+    mock_desc.return_value = [child]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=False)
+
+    jira_client.create_issue_link.assert_not_called()
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_mixed_add_and_remove(mock_desc, _mock_batch):
+    """Simultaneously adds new blockers and removes stale ones."""
+    epic = _issue(
+        "KFLUXDP-30",
+        "Epic",
+        issuelinks=[_blocked_by_link("KFLUXDP-30", "OLD", "50")],
+    )
+    child = _issue(
+        "KFLUXDP-11",
+        "Story",
+        issuelinks=[_blocked_by_link("KFLUXDP-11", "NEW")],
+    )
+    mock_desc.return_value = [child]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=False)
+
+    jira_client.remove_issue_link.assert_called_once_with("50")
+    assert jira_client.create_issue_link.call_count == 1
+    payload = jira_client.create_issue_link.call_args[0][0]
+    assert payload["inwardIssue"]["key"] == "NEW"
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_dry_run_skips_removal_too(mock_desc, _mock_batch):
+    """Dry run must not remove links either."""
+    epic = _issue(
+        "KFLUXDP-30",
+        "Epic",
+        issuelinks=[_blocked_by_link("KFLUXDP-30", "STALE", "50")],
+    )
+    mock_desc.return_value = [_issue("KFLUXDP-11", "Story", issuelinks=[])]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=True)
+
+    jira_client.remove_issue_link.assert_not_called()
+    jira_client.create_issue_link.assert_not_called()
+    assert any("dry-run" in u for u in context["updates"])
+
+
+@mock.patch.dict("os.environ", {"PRIORITIZE_BLOCKER_DIAG": "1"})
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_diag_no_descendants_message(mock_desc, _mock_batch):
+    """PRIORITIZE_BLOCKER_DIAG logs a message when descendants list is empty."""
+    epic = _issue("KFLUXDP-30", "Epic", issuelinks=[])
+    mock_desc.return_value = []
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=True)
+
+    assert any("0 descendants" in u for u in context["updates"])
+
+
+@mock.patch.dict("os.environ", {"PRIORITIZE_BLOCKER_DIAG": "1"})
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_diag_nothing_to_change(mock_desc, _mock_batch):
+    """PRIORITIZE_BLOCKER_DIAG logs when blockers already match."""
+    epic = _issue(
+        "KFLUXDP-30", "Epic", issuelinks=[_blocked_by_link("KFLUXDP-30", "B1", "50")]
+    )
+    child = _issue(
+        "KFLUXDP-11", "Story", issuelinks=[_blocked_by_link("KFLUXDP-11", "B1")]
+    )
+    mock_desc.return_value = [child]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=True)
+
+    assert any("nothing to change" in u for u in context["updates"])
+
+
+@mock.patch.dict("os.environ", {"PRIORITIZE_BLOCKER_DIAG": "2"})
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_diag_level2_debug_output(mock_desc, _mock_batch):
+    """PRIORITIZE_BLOCKER_DIAG=2 emits detailed debug info."""
+    epic = _issue("KFLUXDP-30", "Epic", issuelinks=[])
+    child = _issue(
+        "KFLUXDP-11", "Story", issuelinks=[_blocked_by_link("KFLUXDP-11", "B1")]
+    )
+    mock_desc.return_value = [child]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=True)
+
+    debug_msgs = [u for u in context["updates"] if "DEBUG" in u]
+    assert len(debug_msgs) == 1
+    assert "descendant_keys" in debug_msgs[0]
+    assert "to_add" in debug_msgs[0]
+
+
+@mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
+@mock.patch("rules.team.blocker_propagation.get_descendant_issues")
+def test_sync_ignores_resolved_children(mock_desc, _mock_batch):
+    """Resolved children's blockers should not propagate to the parent."""
+    epic = _issue("KFLUXDP-30", "Epic", issuelinks=[])
+    _issue(
+        "KFLUXDP-11",
+        "Story",
+        issuelinks=[_blocked_by_link("KFLUXDP-11", "B1")],
+        resolution="Done",
+    )
+    open_child = _issue(
+        "KFLUXDP-12",
+        "Story",
+        issuelinks=[_blocked_by_link("KFLUXDP-12", "B2")],
+    )
+    mock_desc.return_value = [open_child]
+
+    jira_client = mock.Mock()
+    context = {"jira_client": jira_client, "updates": []}
+    bp.sync_blocker_links_from_descendants(epic, context, dry_run=False)
+
+    mock_desc.assert_called_once_with(jira_client, "KFLUXDP-30", unresolved_only=True)
+    calls = jira_client.create_issue_link.call_args_list
+    assert len(calls) == 1
+    payload = calls[0][0][0]
+    assert payload["inwardIssue"]["key"] == "B2"
+    assert payload["outwardIssue"]["key"] == "KFLUXDP-30"
+
+
+def _child(key, resolution=None):
+    fields = {"resolution": {"name": resolution} if resolution else None}
+    return {"key": key, "fields": fields}
+
+
+def _mock_children(tree):
+    """Build a side_effect for get_children from a dict {parent_key: [child, ...]}."""
+
+    def _side_effect(jira_client, stub, order_by=""):
+        return iter(tree.get(stub["key"], []))
+
+    return _side_effect
+
+
+@mock.patch("utils.jira.get_children")
+def test_descendant_bfs_single_level(mock_gc):
+    mock_gc.side_effect = _mock_children(
+        {"ROOT": [_child("A"), _child("B")], "A": [], "B": []}
+    )
+    result = get_descendant_issues(mock.Mock(), "ROOT")
+    assert [c["key"] for c in result] == ["A", "B"]
+
+
+@mock.patch("utils.jira.get_children")
+def test_descendant_bfs_multi_level(mock_gc):
+    mock_gc.side_effect = _mock_children(
+        {
+            "ROOT": [_child("A")],
+            "A": [_child("B"), _child("C")],
+            "B": [_child("D")],
+            "C": [],
+            "D": [],
+        }
+    )
+    result = get_descendant_issues(mock.Mock(), "ROOT")
+    assert [c["key"] for c in result] == ["A", "B", "C", "D"]
+
+
+@mock.patch("utils.jira.get_children")
+def test_descendant_cycle_protection(mock_gc):
+    """A child pointing back to an ancestor should not cause infinite recursion."""
+    mock_gc.side_effect = _mock_children(
+        {
+            "ROOT": [_child("A")],
+            "A": [_child("B")],
+            "B": [_child("ROOT"), _child("A")],
+        }
+    )
+    result = get_descendant_issues(mock.Mock(), "ROOT")
+    assert [c["key"] for c in result] == ["A", "B"]
+
+
+@mock.patch("utils.jira.get_children")
+def test_descendant_unresolved_only_filters_resolved(mock_gc):
+    mock_gc.side_effect = _mock_children(
+        {
+            "ROOT": [_child("OPEN"), _child("DONE", resolution="Done")],
+            "OPEN": [_child("DEEP")],
+            "DEEP": [],
+        }
+    )
+    result = get_descendant_issues(mock.Mock(), "ROOT", unresolved_only=True)
+    keys = [c["key"] for c in result]
+    assert "OPEN" in keys
+    assert "DEEP" in keys
+    assert "DONE" not in keys
+
+
+@mock.patch("utils.jira.get_children")
+def test_descendant_unresolved_only_skips_subtree(mock_gc):
+    """Resolved node's children should not be traversed."""
+    subtree_visited = []
+
+    def _side_effect(jira_client, stub, order_by=""):
+        subtree_visited.append(stub["key"])
+        tree = {
+            "ROOT": [_child("CLOSED", resolution="Done")],
+            "CLOSED": [_child("HIDDEN")],
+            "HIDDEN": [],
+        }
+        return iter(tree.get(stub["key"], []))
+
+    mock_gc.side_effect = _side_effect
+    result = get_descendant_issues(mock.Mock(), "ROOT", unresolved_only=True)
+    assert [c["key"] for c in result] == []
+    assert "CLOSED" not in subtree_visited, "Should not traverse into resolved node"
+
+
+@mock.patch("utils.jira.get_children")
+def test_descendant_no_children(mock_gc):
+    mock_gc.side_effect = _mock_children({"ROOT": []})
+    result = get_descendant_issues(mock.Mock(), "ROOT")
+    assert result == []
+
+
+@mock.patch("utils.jira.get_children")
+def test_descendant_root_excluded_from_results(mock_gc):
+    mock_gc.side_effect = _mock_children({"ROOT": [_child("A")], "A": []})
+    result = get_descendant_issues(mock.Mock(), "ROOT")
+    assert all(c["key"] != "ROOT" for c in result)
+
+
+def test_batch_merge_populates_issuelinks():
+    """Batch fetch should write issuelinks into each issue's fields."""
+    link_a = _blocked_by_link("A", "B1")
+    link_b = _blocked_by_link("B", "B2")
+    jira_client = mock.Mock()
+    jira_client.enhanced_jql.return_value = {
+        "issues": [
+            {"key": "A", "fields": {"issuelinks": [link_a]}},
+            {"key": "B", "fields": {"issuelinks": [link_b]}},
+        ],
+        "nextPageToken": None,
+    }
+
+    issue_a: dict = {"key": "A", "fields": {}}
+    issue_b: dict = {"key": "B", "fields": {}}
+    bp._batch_merge_issuelinks(jira_client, [issue_a, issue_b])
+
+    assert issue_a["fields"]["issuelinks"] == [link_a]
+    assert issue_b["fields"]["issuelinks"] == [link_b]
+    assert jira_client.enhanced_jql.call_count == 1
+
+
+def test_batch_merge_handles_pagination():
+    """Multiple pages should all be processed."""
+    link_a = _blocked_by_link("A", "B1")
+    link_b = _blocked_by_link("B", "B2")
+    jira_client = mock.Mock()
+    jira_client.enhanced_jql.side_effect = [
+        {
+            "issues": [{"key": "A", "fields": {"issuelinks": [link_a]}}],
+            "nextPageToken": "page2",
+        },
+        {
+            "issues": [{"key": "B", "fields": {"issuelinks": [link_b]}}],
+            "nextPageToken": None,
+        },
+    ]
+
+    issue_a: dict = {"key": "A", "fields": {}}
+    issue_b: dict = {"key": "B", "fields": {}}
+    bp._batch_merge_issuelinks(jira_client, [issue_a, issue_b])
+
+    assert issue_a["fields"]["issuelinks"] == [link_a]
+    assert issue_b["fields"]["issuelinks"] == [link_b]
+    assert jira_client.enhanced_jql.call_count == 2
+
+
+def test_batch_merge_empty_list():
+    """Empty input should not call the API."""
+    jira_client = mock.Mock()
+    bp._batch_merge_issuelinks(jira_client, [])
+    jira_client.enhanced_jql.assert_not_called()
+
+
+def test_batch_merge_none_response():
+    """None response from enhanced_jql should be handled gracefully."""
+    jira_client = mock.Mock()
+    jira_client.enhanced_jql.return_value = None
+
+    issue: dict = {"key": "A", "fields": {"issuelinks": [{"old": True}]}}
+    bp._batch_merge_issuelinks(jira_client, [issue])
+
+    assert issue["fields"]["issuelinks"] == [{"old": True}]
+
+
+def test_batch_merge_splits_large_batches():
+    """More than _BATCH_SIZE issues should produce multiple JQL queries."""
+    issues = [{"key": f"K-{i}", "fields": {}} for i in range(bp._BATCH_SIZE + 10)]
+    jira_client = mock.Mock()
+    jira_client.enhanced_jql.return_value = {"issues": [], "nextPageToken": None}
+
+    bp._batch_merge_issuelinks(jira_client, issues)
+
+    assert jira_client.enhanced_jql.call_count == 2
+    first_jql = jira_client.enhanced_jql.call_args_list[0][0][0]
+    assert first_jql.startswith("key in (")
+
+
+def test_batch_merge_null_issuelinks_stored_as_empty():
+    """issuelinks: null in the response should be stored as []."""
+    jira_client = mock.Mock()
+    jira_client.enhanced_jql.return_value = {
+        "issues": [{"key": "A", "fields": {"issuelinks": None}}],
+        "nextPageToken": None,
+    }
+
+    issue: dict = {"key": "A", "fields": {}}
+    bp._batch_merge_issuelinks(jira_client, [issue])
+
+    assert issue["fields"]["issuelinks"] == []

--- a/src/tests/test_jira.py
+++ b/src/tests/test_jira.py
@@ -1,9 +1,12 @@
 """Tests for Jira utilities (caching, preprocess helpers)."""
 
+import unittest.mock as mock
+
 import dogpile.cache
 import pytest
 
-from utils.jira import preprocess
+import utils.jira as jira_mod
+from utils.jira import get_fields_ids, preprocess, query_issues, rank_issues
 
 
 def _minimal_field_ids():
@@ -25,6 +28,15 @@ def memory_jira_cache(monkeypatch):
         expiration_time=3600,
     )
     monkeypatch.setattr("utils.jira.cache", region)
+
+
+@pytest.fixture(autouse=True)
+def _reset_field_ids_cache():
+    """Ensure the module-level cache doesn't leak between tests."""
+    original = jira_mod._field_ids_cache
+    jira_mod._field_ids_cache = None
+    yield
+    jira_mod._field_ids_cache = original
 
 
 def test_get_parent_cache_shared_ref_one_get_issue(monkeypatch, memory_jira_cache):
@@ -56,3 +68,104 @@ def test_get_parent_cache_shared_ref_one_get_issue(monkeypatch, memory_jira_cach
     pb = issue_b["Context"]["Related Issues"]["Parent"]
     assert pa is not None and pb is not None
     assert pa is pb
+
+
+@mock.patch("utils.jira._search")
+def test_query_issues_builds_correct_jql(mock_search):
+    """query_issues should produce Cloud-compatible JQL with resolution IS EMPTY."""
+    mock_search.return_value = [{"key": "P-1"}]
+    result = query_issues(
+        mock.Mock(), "PROJ", "filter!=999", "Epic", "rank ASC", verbose=False
+    )
+    jql = mock_search.call_args[0][1]
+    assert "resolution IS EMPTY" in jql
+    assert "issuetype=Epic" in jql
+    assert "AND filter!=999" in jql
+    assert jql.endswith("ORDER BY rank ASC")
+    assert result == [{"key": "P-1"}]
+
+
+@mock.patch("utils.jira._search")
+def test_query_issues_omits_subquery_when_empty(mock_search):
+    mock_search.return_value = [{"key": "P-1"}]
+    query_issues(mock.Mock(), "PROJ", "", "Story", "rank ASC", verbose=False)
+    jql = mock_search.call_args[0][1]
+    assert "project=PROJ AND resolution IS EMPTY AND issuetype=Story" in jql
+    assert jql.count("AND") == 2
+
+
+@mock.patch("utils.jira._search")
+def test_query_issues_omits_order_when_empty(mock_search):
+    mock_search.return_value = [{"key": "P-1"}]
+    query_issues(mock.Mock(), "PROJ", "", "Epic", "", verbose=False)
+    jql = mock_search.call_args[0][1]
+    assert "ORDER BY" not in jql
+
+
+def test_search_prints_hint_on_empty_results(monkeypatch, memory_jira_cache, capsys):
+    """When verbose search returns 0 results, the diagnostic hint should print."""
+    monkeypatch.setattr("utils.jira._jql_fields_list", lambda jc: ["summary"])
+
+    jira_client = mock.Mock()
+    jira_client.enhanced_jql.return_value = {
+        "issues": [],
+        "nextPageToken": None,
+    }
+
+    from utils.jira import _search
+
+    _search(jira_client, "project=X AND issuetype=Epic", verbose=True)
+    captured = capsys.readouterr().out
+    assert "If unexpected" in captured
+    assert "0 results" in captured
+
+
+def test_search_no_hint_when_results_found(monkeypatch, memory_jira_cache, capsys):
+    monkeypatch.setattr("utils.jira._jql_fields_list", lambda jc: ["summary"])
+
+    jira_client = mock.Mock()
+    jira_client.enhanced_jql.return_value = {
+        "issues": [{"key": "X-1"}],
+        "nextPageToken": None,
+    }
+
+    from utils.jira import _search
+
+    _search(jira_client, "project=X AND issuetype=Epic WITH_RESULTS", verbose=True)
+    captured = capsys.readouterr().out
+    assert "1 results" in captured
+    assert "If unexpected" not in captured
+
+
+def test_get_fields_ids_returns_cache_on_second_call():
+    """Second call should hit _field_ids_cache and skip the API entirely."""
+    fake_fields = [
+        {"name": "Rank", "id": "cf_rank"},
+        {"name": "Target start", "id": "cf_ts"},
+        {"name": "Target end", "id": "cf_te"},
+        {"name": "Due date", "id": "cf_due"},
+        {"name": "RICE Score", "id": "cf_rice"},
+        {"name": "Parent", "id": "cf_parent"},
+    ]
+
+    jira_client = mock.Mock()
+    jira_client.get_all_fields.return_value = fake_fields
+
+    first = get_fields_ids(jira_client)
+    assert jira_client.get_all_fields.call_count == 1
+
+    second = get_fields_ids(jira_client)
+    assert jira_client.get_all_fields.call_count == 1
+    assert first is second
+
+
+def test_rank_issues_returns_early_on_empty_new_ranking():
+    rank_issues([], [{"_jira_client": mock.Mock()}], dry_run=False)
+
+
+def test_rank_issues_returns_early_on_empty_old_ranking():
+    rank_issues([{"_jira_client": mock.Mock()}], [], dry_run=False)
+
+
+def test_rank_issues_returns_early_on_both_empty():
+    rank_issues([], [], dry_run=False)

--- a/src/utils/jira.py
+++ b/src/utils/jira.py
@@ -179,7 +179,7 @@ def query_issues(
     order_by: str,
     verbose: bool = True,
 ) -> list:
-    query = f"project={project_id} AND resolution=Unresolved AND type={issue_type}"
+    query = f"project={project_id} AND resolution IS EMPTY AND issuetype={issue_type}"
     if subquery:
         query += f" AND {subquery}"
     if order_by:
@@ -235,6 +235,12 @@ def _search(jira_client: Jira, query: str, verbose: bool) -> list:
 
         if verbose:
             print("  =", f"{len(results)} results:", [r["key"] for r in results])
+            if not results:
+                print(
+                    "  ! If unexpected: paste the JQL into Jira (Issues → Search). "
+                    "No rows means no matching issues for this user, or issue types "
+                    "differ from Epic/Feature (team-managed projects)."
+                )
         return results
 
     return __search(query, verbose)
@@ -270,6 +276,7 @@ def is_archived_component(jira_client, component_id):
     return _is_archived_component(component_id)
 
 
+@retry()
 def get_fields_ids(jira_client: Jira) -> dict[str, str]:
     global _field_ids_cache
     if _field_ids_cache is not None:
@@ -330,6 +337,37 @@ def get_blocks(jira_client: Jira, issue: dict) -> list[dict]:
 
 def get_children(jira_client: Jira, issue: dict, order_by: str = "") -> LazyChildIssues:
     return LazyChildIssues(jira_client, issue, order_by)
+
+
+def get_descendant_issues(
+    jira_client: Jira, root_key: str, unresolved_only: bool = False
+) -> list[dict]:
+    """
+    All strict descendants of ``root_key`` (BFS): ``Parent`` and/or Epic Link to ``root_key``,
+    then ``Parent`` / Epic Link on deeper levels. Uses ``get_children`` for preprocessing.
+
+    When ``unresolved_only`` is True, resolved/closed children are excluded from traversal.
+    This avoids propagating blockers from issues that are already done.
+    """
+    collected: list[dict] = []
+    frontier = [root_key]
+    seen = {root_key}
+    while frontier:
+        parent_key = frontier.pop(0)
+        stub = {"key": parent_key, "fields": {}}
+        children = get_children(jira_client, stub)
+        for ch in children:
+            ck = ch["key"]
+            if ck in seen:
+                continue
+            if unresolved_only:
+                resolution = (ch.get("fields") or {}).get("resolution")
+                if resolution is not None:
+                    continue
+            seen.add(ck)
+            collected.append(ch)
+            frontier.append(ck)
+    return collected
 
 
 def get_version(jira_client: Jira, project: dict, version: str):
@@ -394,6 +432,8 @@ def set_non_compliant_flag(issue: dict, context: dict, dry_run: bool) -> None:
 def rank_issues(
     new_ranking: list[dict], old_ranking: list[dict], dry_run: bool
 ) -> None:
+    if not new_ranking or not old_ranking:
+        return
     jira_client = new_ranking[0]["_jira_client"]
     print(f"\n### Reranking issues ({__name__})")
     previous_issue = None


### PR DESCRIPTION
When a "blocks/is blocked by" link is added to a child issue, automatically add the same blocker relationship to the parent epic/feature.

Jira: https://redhat.atlassian.net/browse/KFLUXDP-744