### PR TITLE
Disable kfluxinfra story ranking

### DIFF
--- a/config/kfluxinfra.yaml
+++ b/config/kfluxinfra.yaml
@@ -19,12 +19,7 @@ team_automation:
             # This is a CEL expression
             ignore: '"orphan" in .labels'
         - check_priority
-        - rule: check_due_date
-          kwargs:
-            # This is a CEL expression
-            # Ignore KFLUXINFRA-34; it gets its own due date
-            ignore: >
-              .key in ["KFLUXINFRA-34"]
+        - check_due_date
         - check_target_dates
         - sync_blocker_links_from_descendants
       group_rules:
@@ -36,5 +31,3 @@ team_automation:
         - check_priority
         - check_quarter_label
         - check_due_date
-      group_rules:
-        - check_rank


### PR DESCRIPTION
The re-ranking of the stories is messing up with the rank of epics. We do not really use stories, we use tasks so disable ranking since either we do both stories/task or none.

If we consider re-enabling tasks/stories ranking, we need to fix the code first to not re-rank the parent also.

Also clean up old due date exclusion, that epic was closed a long time ago.

KFLUXINFRA-3826