### PR TITLE
fix: remove feature propagation

### DIFF
--- a/config/kfluxdp.yaml
+++ b/config/kfluxdp.yaml
@@ -20,6 +20,3 @@ team_automation:
         - sync_blocker_links_from_descendants
       group_rules:
         - check_rank
-    Feature:
-      rules:
-        - sync_blocker_links_from_descendants

--- a/config/konflux.yaml
+++ b/config/konflux.yaml
@@ -27,7 +27,6 @@ team_automation:
       # collector: get_issues
       rules:
         - check_due_date_by_fixversion
-        - sync_blocker_links_from_descendants
       group_rules:
         - rule: check_timesensitive_rank
           kwargs:

--- a/src/rules/team/blocker_propagation.py
+++ b/src/rules/team/blocker_propagation.py
@@ -1,6 +1,6 @@
 """
 When a child issue gains or loses a "is blocked by" link, the next bot run adds or removes the
-corresponding link on the parent issue so parents reflect rollup state.
+corresponding link on the parent Epic so Epics reflect rollup state.
 """
 
 from __future__ import annotations
@@ -110,12 +110,12 @@ def sync_blocker_links_from_descendants(
     **_: Any,
 ) -> None:
     """
-    For an Epic or Feature, set "is blocked by" to exactly the union of blockers on
-    all descendant issues (any issue type under the Parent hierarchy), adding and
+    For an Epic, set "is blocked by" to exactly the union of blockers on all
+    descendant issues (any issue type under the Parent hierarchy), adding and
     removing Issue Links as needed.
     """
     if container_issue_types is None:
-        container_issue_types = ("Epic", "Feature")
+        container_issue_types = ("Epic",)
 
     itype = (issue["fields"].get("issuetype") or {}).get("name")
     if itype not in container_issue_types:

--- a/src/tests/test_blocker_propagation.py
+++ b/src/tests/test_blocker_propagation.py
@@ -295,23 +295,17 @@ def test_inward_blocks_entries_skips_non_blocks_and_missing_id():
 
 @mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")
 @mock.patch("rules.team.blocker_propagation.get_descendant_issues")
-def test_sync_works_on_feature(mock_desc, _mock_batch):
-    """Feature is a valid container type, not just Epic."""
+def test_sync_skips_feature(mock_desc, _mock_batch):
+    """Feature is not a container type; blocker propagation only applies to Epics."""
     feature = _issue("KONFLUX-100", "Feature", issuelinks=[])
-    child = _issue(
-        "KONFLUX-200", "Epic", issuelinks=[_blocked_by_link("KONFLUX-200", "EXT-1")]
-    )
-    mock_desc.return_value = [child]
+    mock_desc.return_value = []
 
     jira_client = mock.Mock()
     context = {"jira_client": jira_client, "updates": []}
     bp.sync_blocker_links_from_descendants(feature, context, dry_run=False)
 
-    calls = jira_client.create_issue_link.call_args_list
-    assert len(calls) == 1
-    payload = calls[0][0][0]
-    assert payload["inwardIssue"]["key"] == "EXT-1"
-    assert payload["outwardIssue"]["key"] == "KONFLUX-100"
+    mock_desc.assert_not_called()
+    jira_client.create_issue_link.assert_not_called()
 
 
 @mock.patch("rules.team.blocker_propagation._batch_merge_issuelinks")


### PR DESCRIPTION
Removes the feature rule from kfluxdp.yaml and the propagation rule from konflux.yaml
The rule now only affects Epics
Tests reworked to ensure features are skipped